### PR TITLE
Adds missing ceph.conf template, and updates render logic

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -234,11 +234,8 @@ def ceph_storage(ceph_admin):
     if not os.path.isdir(etc_ceph_directory):
         os.makedirs(etc_ceph_directory)
     charm_ceph_conf = os.path.join(etc_ceph_directory, 'ceph.conf')
-    try:
-        with open(charm_ceph_conf, 'w') as ceph_conf:
-            ceph_conf.write(render('ceph.conf', ceph_context))
-    except IOError as err:
-        hookenv.log("IOError writing ceph.conf: {}".format(err))
+    # Render the ceph configuration from the ceph conf template
+    render('ceph.conf', charm_ceph_conf, ceph_context)
 
     admin_key = os.path.join(etc_ceph_directory, 'ceph.client.admin.keyring')
     try:

--- a/cluster/juju/layers/kubernetes-worker/templates/ceph.conf
+++ b/cluster/juju/layers/kubernetes-worker/templates/ceph.conf
@@ -1,0 +1,18 @@
+[global]
+auth cluster required = {{ auth_supported }}
+auth service required = {{ auth_supported }}
+auth client required = {{ auth_supported }}
+keyring = /etc/ceph/$cluster.$name.keyring
+mon host = {{ mon_hosts }}
+fsid = {{ fsid }}
+
+log to syslog = {{ use_syslog }}
+err to syslog = {{ use_syslog }}
+clog to syslog = {{ use_syslog }}
+mon cluster log to syslog = {{ use_syslog }}
+debug mon = {{ loglevel }}/5
+debug osd = {{ loglevel }}/5
+
+[client]
+log file = /var/log/ceph.log
+


### PR DESCRIPTION
The render stanza before was encapsulated in another stream writer, was
missing the target location, and had some extra error handling that
seemed unneccesary
